### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,21 +4,24 @@ from setuptools import find_packages, setup
 pkgname = "vdt.versionplugin.buildout"
 
 setup(name=pkgname,
-      version="0.0.1",
+      version="0.0.2",
       description="Version Increment Plugin that builds with debianize",
       author="CSI",
       author_email="csi@avira.com",
       maintainer="CSI",
       maintainer_email="csi@avira.com",
-      packages=find_packages(exclude=['vdt.versionplugin.buildout']),
+      packages=find_packages(),
       include_package_data=True,
       namespace_packages=['vdt', 'vdt.versionplugin'],
       zip_safe=True,
       install_requires=[
           "setuptools",
-          "mock",
           "vdt.version",
           "vdt.versionplugin.default",
       ],
       entry_points={},
-      )
+      extras_require={
+          'test': [
+              'mock',
+          ]
+      })


### PR DESCRIPTION
Removed  `exclude=['vdt.versionplugin.buildout']` as this breaks the egg so `version` won't find this plugin anymore.

Moved `mock` to `extra_requires`