### PR TITLE
Added missing manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include LICENSE
+include vdt/versionplugin/buildout/files/*
+recursive-include vdt *.py

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 pkgname = "vdt.versionplugin.buildout"
 
 setup(name=pkgname,
-      version="0.0.2",
+      version="0.0.3",
       description="Version Increment Plugin that builds with debianize",
       author="CSI",
       author_email="csi@avira.com",


### PR DESCRIPTION
So when building a source release / egg / wheel the preremove script will be included as well.